### PR TITLE
Update exclude.list

### DIFF
--- a/etc/nfqws/exclude.list
+++ b/etc/nfqws/exclude.list
@@ -4,7 +4,6 @@ keenetic.pro
 keenetic.link
 keenetic.name
 omni.ru
-google.com
 dns.google
 gosuslugi.ru
 gov.ru


### PR DESCRIPTION
Delete google.com from exclude.list, to allow subdomains (blocked by TSPU) like play.google.com to be processed by nfqws.