### PR TITLE
Add IP-based filtering for bypass functionality

### DIFF
--- a/common/ipk/conffiles
+++ b/common/ipk/conffiles
@@ -2,3 +2,4 @@
 /opt/etc/nfqws/user.list
 /opt/etc/nfqws/auto.list
 /opt/etc/nfqws/exclude.list
+/opt/etc/nfqws/allowed_ips.list

--- a/etc/init.d/common
+++ b/etc/init.d/common
@@ -37,7 +37,21 @@ _RULE_NFQWS() {
   local PORTS=$2 # 80,443
 
   # Main NFQUEUE rule
-  echo "POSTROUTING -o $IFACE -t mangle -p $PROTO -m multiport --dports $PORTS -m connbytes --connbytes-dir=original --connbytes-mode=packets --connbytes 1:8 -m mark ! --mark $MARK_EXCLUDE -j NFQUEUE --queue-num $NFQUEUE_NUM --queue-bypass"
+  local RULE="POSTROUTING -o $IFACE -t mangle -p $PROTO -m multiport --dports $PORTS -m connbytes --connbytes-dir=original --connbytes-mode=packets --connbytes 1:8 -m mark ! --mark $MARK_EXCLUDE"
+
+  # Add IP check if allowed_ips.list exists and is not empty
+  if [ -f "$ALLOWED_IPS_FILE" ] && [ -s "$ALLOWED_IPS_FILE" ]; then
+    # Read IPs from file, skip comments and empty lines
+    local IPS=$(grep -v '^#' "$ALLOWED_IPS_FILE" | grep -v '^$' | tr '\n' ',')
+    if [ -n "$IPS" ]; then
+      # Remove trailing comma
+      IPS=${IPS%,}
+      RULE="$RULE -m iprange --src-range $IPS"
+    fi
+  fi
+
+  RULE="$RULE -j NFQUEUE --queue-num $NFQUEUE_NUM --queue-bypass"
+  echo "$RULE"
 }
 
 _RULE_MASQ() {
@@ -107,6 +121,7 @@ create_running_config() {
   echo "POLICY_EXCLUDE=$POLICY_EXCLUDE" >> "$CONFFILE.run"
   echo "POLICY_MARK=\"$POLICY_MARK\"" >> "$CONFFILE.run"
   echo "NFQUEUE_NUM=$NFQUEUE_NUM" >> "$CONFFILE.run"
+  echo "ALLOWED_IPS_FILE=\"$ALLOWED_IPS_FILE\"" >> "$CONFFILE.run"
 }
 
 remove_running_config() {

--- a/etc/nfqws/allowed_ips.list
+++ b/etc/nfqws/allowed_ips.list
@@ -1,0 +1,7 @@
+# List of IP addresses for which bypass will work
+# One IP address per line
+# If file is empty, bypass will work for all IP addresses
+# Examples:
+# 192.168.1.100
+# 192.168.1.101
+# 192.168.1.102 

--- a/etc/nfqws/nfqws.conf
+++ b/etc/nfqws/nfqws.conf
@@ -38,6 +38,10 @@ POLICY_EXCLUDE=0
 # Syslog logging level (0 - silent, 1 - debug)
 LOG_LEVEL=0
 
+# File with list of IP addresses for which bypass will work
+# If file is empty or doesn't exist, bypass will work for all IPs
+ALLOWED_IPS_FILE="/opt/etc/nfqws/allowed_ips.list"
+
 NFQUEUE_NUM=200
 USER=nobody
-CONFIG_VERSION=6
+CONFIG_VERSION=7


### PR DESCRIPTION
feat: add IP-based bypass filtering

Add ability to restrict bypass functionality to specific IP addresses. This feature allows users to control which devices on the network will use the bypass functionality.

Changes:
- Add new configuration file `allowed_ips.list` for managing allowed IP addresses
- Replace `ALLOWED_IPS` parameter with `ALLOWED_IPS_FILE` in nfqws.conf
- Update iptables rules to filter traffic based on source IP addresses
- Add support for comments and empty lines in IP list file
- Increment CONFIG_VERSION to 8

Usage:
1. Edit `/opt/etc/nfqws/allowed_ips.list` to add IP addresses (one per line)
2. If file is empty or doesn't exist, bypass will work for all IPs
3. Restart service to apply changes: `/opt/etc/init.d/S51nfqws restart`

This change improves security and control over which devices can use the bypass functionality.